### PR TITLE
連続で招待を送られた際のエラーメッセージを変更

### DIFF
--- a/srcs/command/CommandInvite.cpp
+++ b/srcs/command/CommandInvite.cpp
@@ -33,7 +33,7 @@ void    Command::invite()
         if (channel->is_client(user->get_fd()) == true)
             throw runtime_error(err_443(_user, channel_name));
         else if (channel->is_invited(user->get_fd()) == true)
-            throw runtime_error(err_443(_user, channel_name)); // what is already invited error code ???
+            throw runtime_error(err_800(_user, channel_name));
         else {
             channel->add_invited(user->get_fd());
             string res = response341(_user, channel_name, invite_nickname);

--- a/srcs/response.cpp
+++ b/srcs/response.cpp
@@ -371,3 +371,18 @@ string response341(User user, string channel_name, string nickname)
     res += "\r\n";
     return res;
 }
+
+
+string err_800(User user, string channel_name)
+{
+    string res;
+    res = USER_IDENTIFIER(user.get_nickname(), user.get_username());
+    res += " 800 ";
+    res += user.get_nickname();
+    res += " ";
+    res += channel_name;
+    res += " ";
+    res += "Already invited to the channel.";
+    res += "\r\n";
+    return res;
+}

--- a/srcs/response.hpp
+++ b/srcs/response.hpp
@@ -94,6 +94,7 @@ string err_475(User user, string channel_name);
 string err_476(User user);
 string err_482(User user, string channel_name);
 string err_696(User user);
+string err_800(User user, string channel_name);
 
 //  332, 353, 366, 324
 


### PR DESCRIPTION
連続で招待を送られた際のエラーメッセージを変更しました。

irssi側では元から表記が出なかったので特に問題はないっぽいです。

ほんとにメッセージ変えただけです。